### PR TITLE
Added regularization

### DIFF
--- a/post_DREX_prediction.m
+++ b/post_DREX_prediction.m
@@ -1,26 +1,26 @@
-function [Psi,X,Y] = post_DREX_prediction(featureidx, out, pred_pos)
+function [Psi,X,Y] = post_DREX_prediction(featureidx, mdl_out, pred_pos)
 % Evaluate predictive distribution from D-REX model output
 %
 % ===INPUT===
 %   featureidx  index of feature to generate predictions from model output
-%   out         output structure of D-REX model
+%   mdl_out     output structure of D-REX model
 %   pred_pos    vector of positions (in feature dimension) at which to evaluate predictive probability
 %
 % ===OUTPUT===
-%   Psi         Predictive probability at each time evaluated at each position (dim: time x position)
-%   X           horizontal positions for plotting Psi
-%   Y           vertical positions for plotting Psi
+%   Psi         Predictive probability at each time evaluated at each position (dim: position x time)
+%   X           mesh grid of horizontal positions for plotting Psi (dimensions: time)
+%   Y           mesh grid of vertical positions for plotting Psi (dimension: feature)
 %
 %   NOTE: see 'display_DREX_output.m' for plotting example
 % 
 
 
-distribution = out.distribution;
+distribution = mdl_out.distribution;
 if strcmp(distribution,'lognormal')
     pred_pos(pred_pos<=0) = [];
 end
-pp = out.prediction_params;
-b = out.context_beliefs; % dim: hyp x time
+pp = mdl_out.prediction_params;
+b = mdl_out.context_beliefs; % dim: hyp x time
 ntime = length(pp);
 nsample = length(pred_pos);
 Psi = zeros(ntime, nsample);
@@ -47,29 +47,19 @@ for t = 1:ntime
                         keyboard;
                     end
                 end
-%             case 'poisson'
-%                 PD(t,:) = PD(t,:) + b_t(ib)*studentpdf(
+            otherwise
+                error('post_DREX_prediction: distribution no supported')
         end
     end
     
 end
 
 [X,Y] = meshgrid(1:ntime, pred_pos); 
-Psi = Psi';
+Psi = Psi'; % Flip for display display_DREX_output.m
 end
-% contourf(Xpos,Ypos,PD',[0.05:0.05:0.3],'fill','off','linestyle','-','linecolor',0.6*[1 1 1])
 
 
 function p = studentpdf(x, mu, var, n)
 c = exp(gammaln(n/2 + 0.5) - gammaln(n/2)) .* (n.*pi.*var).^(-0.5);
 p = c .* (1 + (1./(n.*var)).*(x-mu).^2).^(-(n+1)/2);
-end
-
-function p = poissonpdf(x, lambda)
-if abs(x - round(x)) > 1e-1
-    error('Poisson PDF input x must be an integer.');
-else
-    x = round(x);
-end
-p = ((lambda.^x) / factorial(x)) .* exp(-lambda);
 end


### PR DESCRIPTION
Ensures covariance estimate in prior estimation is positive-definite. Problem occurs for D>>1 with very slow-moving input features (i.e., highly correlated). Regularization is essentially the same as added gaussian noise: adds identity matrix with enough weight to make all eigenvalues of resulting cov estimate >= 0. 